### PR TITLE
fix: terraform code fixes, dynamodb table name change

### DIFF
--- a/.env
+++ b/.env
@@ -8,6 +8,9 @@ TF_VAR_project = ${TF_VAR_project}
 
 TF_VAR_owner_email=${TF_VAR_owner_email}
 
+TF_VAR_s3_bucket_name = ${TF_VAR_s3_bucket_name}
+TF_VAR_s3_bucket_key_prefix = ${TF_VAR_s3_bucket_key_prefix}
+
 TF_VAR_dynamodb_lock_table_name = ${TF_VAR_dynamodb_lock_table_name}
 
 TF_VAR_codepipeline_artifacts_s3_bucket_name = ${TF_VAR_codepipeline_artifacts_s3_bucket_name}

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ TF_S3_BUCKET_KEY_PREFIX := terraform
 
 TF_WORKSPACE_KEY_PREFIX := ${TF_S3_BUCKET_KEY_PREFIX}/${PROJECT_NAME}
 TF_WORKSPACE_NAME := ${ENV}
-TF_DYNAMODB_LOCK_TABLE_NAME := ${PROJECT_NAME}_${ENV}-terraform-lock
+TF_DYNAMODB_LOCK_TABLE_NAME := ${PROJECT_NAME}-${ENV}-terraform-lock
 
 TF_CLI := docker-compose run --rm terraform_container
 
@@ -24,7 +24,11 @@ TF_VAR_project = ${PROJECT_NAME}
 
 TF_VAR_owner_email = <myemailaddress>
 
+TF_VAR_s3_bucket_name = ${TF_S3_BUCKET_NAME}
+TF_VAR_s3_bucket_key_prefix = ${TF_S3_BUCKET_KEY_PREFIX}
+
 TF_VAR_dynamodb_lock_table_name = ${TF_DYNAMODB_LOCK_TABLE_NAME}
+
 TF_VAR_codepipeline_artifacts_s3_bucket_name = ${TF_S3_BUCKET_NAME}
 TF_VAR_codepipeline_artifacts_s3_bucket_kms_key_alias = ${TF_S3_BUCKET_NAME}-${ENV}
 
@@ -55,17 +59,21 @@ all: usage
 usage:
 	@echo
 	@echo === Help: Command Reference ===
-	@echo make terraform_fmt     - format the terraform files in the standard style.
-	@echo make terraform_init    - initialise the terraform project.
-	@echo make terraform_plan    - create a plan for the changes that will be deployed.
-	@echo make terraform_apply   - apply the changes from the plan stage
-	@echo make terraform_destroy - destroy all that was deployed
+	@echo make terraform_fmt      - format the terraform files in the standard style.
+	@echo make terraform_validate - validates the terraform code.
+	@echo make terraform_init     - initialise the terraform project.
+	@echo make terraform_plan     - create a plan for the changes that will be deployed.
+	@echo make terraform_apply    - apply the changes from the plan stage
+	@echo make terraform_destroy  - destroy all that was deployed
 	@echo make - show this help
 	@echo 
 
 terraform_fmt:
 	${TF_CLI} -chdir=${TF_FOLDER} fmt -recursive .	
-	
+
+terraform_validate:
+	${TF_CLI}  -chdir=${TF_FOLDER} validate
+		
 terraform_init:
 	${TF_CLI} -chdir=${TF_FOLDER} init \
       -backend=true \

--- a/_prerequsities/Makefile
+++ b/_prerequsities/Makefile
@@ -10,7 +10,7 @@ TF_S3_BUCKET_NAME := <mys3bucketname>
 # store the terraform state files inside a root folder in the s3 bucket
 TF_S3_BUCKET_KEY_PREFIX := terraform
 TF_WORKSPACE_KEY_PREFIX := ${TF_S3_BUCKET_KEY_PREFIX}/${PROJECT_NAME}
-TF_DYNAMODB_LOCK_TABLE_NAME := ${PROJECT_NAME_PREFIX}_${ENV}-terraform-lock
+TF_DYNAMODB_LOCK_TABLE_NAME := ${PROJECT_NAME_PREFIX}-${ENV}-terraform-lock
 TF_WORKSPACE_NAME := ${ENV}
 
 TF_CLI := docker-compose run --rm terraform_container
@@ -30,17 +30,21 @@ all: usage
 usage:
 	@echo
 	@echo === Help: Command Reference ===
-	@echo make terraform_fmt     - format the terraform files in the standard style.
-	@echo make terraform_init    - initialise the terraform project.
-	@echo make terraform_plan    - create a plan for the changes that will be deployed.
-	@echo make terraform_apply   - apply the changes from the plan stage
-	@echo make terraform_destroy - destroy all that was deployed
+	@echo make terraform_fmt      - format the terraform files in the standard style.
+	@echo make terraform_validate - validates the terraform code.
+	@echo make terraform_init     - initialise the terraform project.
+	@echo make terraform_plan     - create a plan for the changes that will be deployed.
+	@echo make terraform_apply    - apply the changes from the plan stage
+	@echo make terraform_destroy  - destroy all that was deployed
 	@echo make - show this help
 	@echo 
 
 terraform_fmt:
 	${TF_CLI}  -chdir=${TF_FOLDER} fmt -recursive .	
-	
+
+terraform_validate:
+	${TF_CLI}  -chdir=${TF_FOLDER} validate
+		
 terraform_init:
 	${TF_CLI}  -chdir=${TF_FOLDER} init
 

--- a/_prerequsities/scripts/migrate_terraform_statefile.sh
+++ b/_prerequsities/scripts/migrate_terraform_statefile.sh
@@ -8,7 +8,13 @@ aws s3 cp ./terraform/terraform.tfstate s3://${TF_S3_BUCKET_NAME}/${TF_WORKSPACE
 echo "[INFO] moving local state files to backup folder"
 mkdir -v ./tfstatebackup
 mv -v ./terraform/terraform.tfstate ./tfstatebackup
-mv -v ./terraform/terraform.tfstate.backup ./tfstatebackup
+
+if [ -f "./terraform/terraform.tfstate.backup" ]; then
+    mv -v ./terraform/terraform.tfstate.backup ./tfstatebackup
+else
+    echo "[INFO] ./terraform/terraform.tfstate.backup file not found. Skipping"
+fi
+
 mv -v ./terraform/.terraform.lock.hcl ./tfstatebackup
 
 echo "[INFO] copying _backend.tf to terraform folder"

--- a/_prerequsities/temp/Makefile.localbackend
+++ b/_prerequsities/temp/Makefile.localbackend
@@ -10,7 +10,7 @@ TF_S3_BUCKET_NAME := <mys3bucketname>
 # store the terraform state files inside a root folder in the s3 bucket
 TF_S3_BUCKET_KEY_PREFIX := terraform
 TF_WORKSPACE_KEY_PREFIX := ${TF_S3_BUCKET_KEY_PREFIX}/${PROJECT_NAME}
-TF_DYNAMODB_LOCK_TABLE_NAME := ${PROJECT_NAME_PREFIX}_${ENV}-terraform-lock
+TF_DYNAMODB_LOCK_TABLE_NAME := ${PROJECT_NAME_PREFIX}-${ENV}-terraform-lock
 TF_WORKSPACE_NAME := ${ENV}
 
 TF_CLI := docker-compose run --rm terraform_container
@@ -30,17 +30,21 @@ all: usage
 usage:
 	@echo
 	@echo === Help: Command Reference ===
-	@echo make terraform_fmt     - format the terraform files in the standard style.
-	@echo make terraform_init    - initialise the terraform project.
-	@echo make terraform_plan    - create a plan for the changes that will be deployed.
-	@echo make terraform_apply   - apply the changes from the plan stage
-	@echo make terraform_destroy - destroy all that was deployed
+	@echo make terraform_fmt      - format the terraform files in the standard style.
+	@echo make terraform_validate - validates the terraform code.
+	@echo make terraform_init     - initialise the terraform project.
+	@echo make terraform_plan     - create a plan for the changes that will be deployed.
+	@echo make terraform_apply    - apply the changes from the plan stage
+	@echo make terraform_destroy  - destroy all that was deployed
 	@echo make - show this help
 	@echo 
 
 terraform_fmt:
 	${TF_CLI}  -chdir=${TF_FOLDER} fmt -recursive .	
-	
+
+terraform_validate:
+	${TF_CLI}  -chdir=${TF_FOLDER} validate
+
 terraform_init:
 	${TF_CLI}  -chdir=${TF_FOLDER} init
 

--- a/_prerequsities/temp/Makefile.s3backend
+++ b/_prerequsities/temp/Makefile.s3backend
@@ -10,7 +10,7 @@ TF_S3_BUCKET_NAME := <mys3bucketname>
 # store the terraform state files inside a root folder in the s3 bucket
 TF_S3_BUCKET_KEY_PREFIX := terraform
 TF_WORKSPACE_KEY_PREFIX := ${TF_S3_BUCKET_KEY_PREFIX}/${PROJECT_NAME}
-TF_DYNAMODB_LOCK_TABLE_NAME := ${PROJECT_NAME_PREFIX}_${ENV}-terraform-lock
+TF_DYNAMODB_LOCK_TABLE_NAME := ${PROJECT_NAME_PREFIX}-${ENV}-terraform-lock
 TF_WORKSPACE_NAME := ${ENV}
 
 TF_CLI := docker-compose run --rm terraform_container
@@ -30,17 +30,21 @@ all: usage
 usage:
 	@echo
 	@echo === Help: Command Reference ===
-	@echo make terraform_fmt     - format the terraform files in the standard style.
-	@echo make terraform_init    - initialise the terraform project.
-	@echo make terraform_plan    - create a plan for the changes that will be deployed.
-	@echo make terraform_apply   - apply the changes from the plan stage
-	@echo make terraform_destroy - destroy all that was deployed
+	@echo make terraform_fmt      - format the terraform files in the standard style.
+	@echo make terraform_validate - validates the terraform code.
+	@echo make terraform_init     - initialise the terraform project.
+	@echo make terraform_plan     - create a plan for the changes that will be deployed.
+	@echo make terraform_apply    - apply the changes from the plan stage
+	@echo make terraform_destroy  - destroy all that was deployed
 	@echo make - show this help
 	@echo 
 
 terraform_fmt:
 	${TF_CLI}  -chdir=${TF_FOLDER} fmt -recursive .	
-	
+
+terraform_validate:
+	${TF_CLI}  -chdir=${TF_FOLDER} validate
+
 terraform_init:
 	${TF_CLI} -chdir=${TF_FOLDER} init \
       -backend=true \

--- a/_prerequsities/terraform/_provider.tf
+++ b/_prerequsities/terraform/_provider.tf
@@ -15,7 +15,7 @@ provider "aws" {
 
   default_tags {
     tags = {
-      Environment = <myenv>
+      Environment = "<myenv>"
       Owner       = "<myname>"
     }
   }

--- a/_prerequsities/terraform/main.tf
+++ b/_prerequsities/terraform/main.tf
@@ -9,19 +9,29 @@ resource "aws_kms_alias" "alias" {
 
 resource "aws_s3_bucket" "s3bucket" {
   bucket = var.s3_bucket_name
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_ownership_controls" "s3bucket" {
+  bucket = aws_s3_bucket.s3bucket.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
   }
+}
 
-  acl = "private"
+resource "aws_s3_bucket_versioning" "s3bucket" {
+  bucket = aws_s3_bucket.s3bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.key.arn
-        sse_algorithm     = "aws:kms"
-      }
+resource "aws_s3_bucket_server_side_encryption_configuration" "s3bucket" {
+  bucket = aws_s3_bucket.s3bucket.id
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.key.arn
+      sse_algorithm     = "aws:kms"
     }
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -58,10 +58,6 @@ resource "aws_codebuild_project" "infra_plan_project" {
       fetch_submodules = true
     }
   }
-
-  tags = {
-    Environment = var.env
-  }
 }
 
 resource "aws_codebuild_project" "infra_apply_project" {
@@ -98,10 +94,6 @@ resource "aws_codebuild_project" "infra_apply_project" {
     git_submodules_config {
       fetch_submodules = true
     }
-  }
-
-  tags = {
-    Environment = var.env
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -9,8 +9,17 @@ variable "project" {
 }
 
 variable "owner_email" {
-  type = string
+  type        = string
   description = "Owner's email address. This will be subscribed to the sns topic that will receive approval requests"
+}
+
+variable "s3_bucket_name" {
+  type        = string
+  description = "Name of the Amazon S3 bucket where Terraform state file will be stored"
+}
+
+variable "s3_bucket_key_prefix" {
+  description = "Key prefix inside which the Terraform state file will be stored in the Amazon S3 bucket"
 }
 
 variable "dynamodb_lock_table_name" {

--- a/test/terraform/_provider.tf
+++ b/test/terraform/_provider.tf
@@ -9,3 +9,7 @@ terraform {
     }
   }
 }
+
+provider "aws" {
+  region = "ap-southeast-2"
+}


### PR DESCRIPTION
## Summary

This PR contains the following changes.
- remove deprecated terraform code from s3 bucket resource block
- remove tags from CodeBuild projects, to fix clashes with default tags
- change dynamodb table name, replace '_' with '-'
- add validate Makefile target to validate Terraform code