### PR TITLE
chore: update admin code, expose codebuild vars to infra terraform project, tidyup variables

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
 AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
 
 TF_VAR_env=${TF_VAR_env}
-TF_VAR_project = ${TF_VAR_project}
+TF_VAR_project_name = ${TF_VAR_project_name}
 
 TF_VAR_infra_approver_email=${TF_VAR_infra_approver_email}
 TF_VAR_app_approver_email=${TF_VAR_app_approver_email}

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ TF_PLAN_FILENAME := ${PROJECT_NAME}_plan.tfplan
 
 # define terraform variables
 TF_VAR_env = ${ENV}
-TF_VAR_project = ${PROJECT_NAME}
+TF_VAR_project_name = ${PROJECT_NAME}
 
 TF_VAR_infra_approver_email = <infraapproveremailaddress>
 TF_VAR_app_approver_email = <appapproveremailaddress>

--- a/admin/Makefile
+++ b/admin/Makefile
@@ -95,7 +95,8 @@ terraform_infra_init:
       -backend-config="key=terraform.tfstate" \
       -backend-config="encrypt=true" \
       -backend-config="dynamodb_table=${TF_DYNAMODB_LOCK_TABLE_NAME}" \
-      -backend-config="workspace_key_prefix=${TF_WORKSPACE_KEY_PREFIX}_infra"
+      -backend-config="workspace_key_prefix=${TF_WORKSPACE_KEY_PREFIX}_infra" \
+	  -var="env=${ENV}"
 
 terraform_app_init:
 	${TF_CLI} -chdir=${TF_FOLDER}/app init \
@@ -104,7 +105,14 @@ terraform_app_init:
       -backend-config="key=terraform.tfstate" \
       -backend-config="encrypt=true" \
       -backend-config="dynamodb_table=${TF_DYNAMODB_LOCK_TABLE_NAME}" \
-      -backend-config="workspace_key_prefix=${TF_WORKSPACE_KEY_PREFIX}_app"
+      -backend-config="workspace_key_prefix=${TF_WORKSPACE_KEY_PREFIX}_app" \
+	  -var="env=${ENV}" \
+	  -var="project_name=${PROJECT_NAME}" \
+	  -var="s3_bucket_name=${TF_S3_BUCKET_NAME}" \
+	  -var="s3_bucket_key_prefix=${TF_S3_BUCKET_KEY_PREFIX}" \
+	  -var="s3_bucket_key=terraform.tfstate" \
+	  -var="region=ap-southeast-2" \
+	  -var="dynamodb_lock_table_name=${TF_DYNAMODB_LOCK_TABLE_NAME}"
 
 terraform_prereq_show:
 	${TF_CLI} -chdir=${TF_FOLDER}/prereq workspace select ${TF_WORKSPACE_NAME} ; \
@@ -132,8 +140,15 @@ terraform_pipeline_destroy:
 
 terraform_infra_destroy:
 	${TF_CLI} -chdir=${TF_FOLDER}/infra workspace select ${TF_WORKSPACE_NAME} ; \
-	${TF_CLI} -chdir=${TF_FOLDER}/infra destroy
+	${TF_CLI} -chdir=${TF_FOLDER}/infra destroy -var="env=${ENV}"
 
 terraform_app_destroy:
 	${TF_CLI} -chdir=${TF_FOLDER}/app workspace select ${TF_WORKSPACE_NAME} ; \
-	${TF_CLI} -chdir=${TF_FOLDER}/app destroy
+	${TF_CLI} -chdir=${TF_FOLDER}/app destroy \
+	-var="env=${ENV}" \
+	-var="project_name=${PROJECT_NAME}" \
+	-var="s3_bucket_name=${TF_S3_BUCKET_NAME}" \
+	-var="s3_bucket_key_prefix=${TF_S3_BUCKET_KEY_PREFIX}" \
+	-var="s3_bucket_key=terraform.tfstate" \
+	-var="region=ap-southeast-2" \
+	-var="dynamodb_lock_table_name=${TF_DYNAMODB_LOCK_TABLE_NAME}"

--- a/admin/terraform/app/_provider.tf
+++ b/admin/terraform/app/_provider.tf
@@ -13,3 +13,28 @@ terraform {
 provider "aws" {
   region = "ap-southeast-2"
 }
+
+data "terraform_remote_state" "infra" {
+  backend = "s3"
+
+  config = {
+    bucket               = var.s3_bucket_name
+    key                  = var.s3_bucket_key
+    region               = var.region
+    encrypt              = true
+    dynamodb_table       = var.dynamodb_lock_table_name
+    workspace_key_prefix = "${var.s3_bucket_key_prefix}/${var.project_name}_infra"
+  }
+
+  workspace = var.env
+}
+
+data "aws_eks_cluster_auth" "eks_cluster" {
+  name = data.terraform_remote_state.infra.outputs.eks_cluster_name
+}
+
+provider "kubernetes" {
+  host                   = data.terraform_remote_state.infra.outputs.eks_endpoint
+  cluster_ca_certificate = base64decode((data.terraform_remote_state.infra.outputs.eks_certificate_authority))
+  token                  = data.aws_eks_cluster_auth.eks_cluster.token
+}

--- a/admin/terraform/app/variables.tf
+++ b/admin/terraform/app/variables.tf
@@ -1,0 +1,29 @@
+variable "env" {
+  description = "The environment name for this deployment"
+}
+
+variable "project_name" {
+  description = "The name of the project"
+}
+
+variable "region" {
+  description = "The AWS region where all resources will be deployed"
+  default     = "ap-southeast-2"
+}
+
+variable "s3_bucket_name" {
+  description = "The name of the Amazon S3 bucket where the terraform state files are stored."
+}
+
+variable "s3_bucket_key_prefix" {
+  description = "The folder name inside which the terraform state files are stored."
+}
+
+variable "s3_bucket_key" {
+  description = "The name of the terraform state file"
+  default     = "terraform.tfstate"
+}
+
+variable "dynamodb_lock_table_name" {
+  description = "The name of the DynamoDB table name that is used to manage concurrent access to terraform state files."
+}

--- a/admin/terraform/infra/_provider.tf
+++ b/admin/terraform/infra/_provider.tf
@@ -13,3 +13,25 @@ terraform {
 provider "aws" {
   region = "ap-southeast-2"
 }
+
+data "aws_eks_cluster" "eks_cluster" {
+  name = "${var.env}-eks-cluster"
+}
+
+data "aws_eks_cluster_auth" "eks_cluster" {
+  name = data.aws_eks_cluster.eks_cluster.name
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.eks_cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.eks_cluster.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.eks_cluster.token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.eks_cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.eks_cluster.certificate_authority[0].data)
+    token                  = data.aws_eks_cluster_auth.eks_cluster.token
+  }
+}

--- a/admin/terraform/infra/variables.tf
+++ b/admin/terraform/infra/variables.tf
@@ -1,0 +1,4 @@
+variable "env" {
+  type        = string
+  description = "The name of the environment where this project is being run. eg dev, test, preprod, prod."
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -3,7 +3,7 @@ data "aws_kms_alias" "codepipeline_artifacts_s3_bucket_kms_key" {
 }
 
 resource "aws_iam_role" "codebuild_service_role" {
-  name = "${var.project}_${var.env}_codebuild_service_role"
+  name = "${var.project_name}_${var.env}_codebuild_service_role"
 
   assume_role_policy = <<EOF
 {
@@ -32,8 +32,8 @@ resource "aws_iam_role_policy" "codebuild_service_role_policy" {
       "Sid": "AccessToAWSCloudWatchLogs",
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:logs:${local.region_name}:${local.account_id}:log-group:/${var.project}/${var.env}/infra/codebuild:*",
-        "arn:aws:logs:${local.region_name}:${local.account_id}:log-group:/${var.project}/${var.env}/app/codebuild:*"
+        "arn:aws:logs:${local.region_name}:${local.account_id}:log-group:/${var.project_name}/${var.env}/infra/codebuild:*",
+        "arn:aws:logs:${local.region_name}:${local.account_id}:log-group:/${var.project_name}/${var.env}/app/codebuild:*"
       ],
       "Action": [
         "logs:CreateLogGroup",
@@ -181,7 +181,7 @@ POLICY
 }
 
 resource "aws_iam_role" "codepipeline_role" {
-  name = "${var.project}_${var.env}_codepipeline_role"
+  name = "${var.project_name}_${var.env}_codepipeline_role"
 
   assume_role_policy = <<EOF
 {
@@ -200,7 +200,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "codepipeline_policy" {
-  name = "${var.project}_${var.env}_codepipeline_policy"
+  name = "${var.project_name}_${var.env}_codepipeline_policy"
   role = aws_iam_role.codepipeline_role.id
 
   policy = <<EOF
@@ -313,7 +313,7 @@ POLICY
 
 
 resource "aws_iam_role" "cloudwatch_events_role" {
-  name = "${var.project}_${var.env}_cloudwatch_events_role"
+  name = "${var.project_name}_${var.env}_cloudwatch_events_role"
 
   assume_role_policy = <<EOF
 {
@@ -332,7 +332,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "cloudwatch_events_policy" {
-  name = "${var.project}_${var.env}_cloudwatch_events_policy"
+  name = "${var.project_name}_${var.env}_cloudwatch_events_policy"
   role = aws_iam_role.cloudwatch_events_role.id
 
   policy = <<EOF

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,11 +8,11 @@ data "aws_s3_bucket" "codepipeline_artifacts_s3_bucket" {
 
 # create a KMS customer managed key that will be used to encrypt the codepipeline artifacts
 resource "aws_kms_key" "codepipeline_kms_key" {
-  description = "KMS key used by ${var.project}-${var.env} CodePipeline pipeline"
+  description = "KMS key used by ${var.project_name}-${var.env} CodePipeline pipeline"
 }
 
 # create an alias for the customer managed KMS key
 resource "aws_kms_alias" "codepipeline_kms_key_alias" {
-  name          = "alias/${var.project}-${var.env}"
+  name          = "alias/${var.project_name}-${var.env}"
   target_key_id = aws_kms_key.codepipeline_kms_key.id
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,7 +3,7 @@ variable "env" {
   description = "The name of the environment where this project is being run. eg dev, test, preprod, prod."
 }
 
-variable "project" {
+variable "project_name" {
   type        = string
   description = "The name of the project"
 }


### PR DESCRIPTION
## Summary

This pull request contains the following changes:
- update to admin code, so that infrastructure and application resources deployed inside the Amazon EKS cluster can be managed (displayed and destroyed)
- fix to infra CodeBuild project environment variables. These are now exposed inside the infrastructure project that the CodeBuild project is working on. Users can now use this inside their infrastructure terraform projects.
- change to the name of the variable **project**. This is now called **project_name**, to keep it consistent with all other places where it is used.