### PR TITLE
chore: add AWS SSM Parameter Store permissions to AWS CodeBuild Service role

### DIFF
--- a/_prerequisites/scripts/migrate_terraform_statefile.sh
+++ b/_prerequisites/scripts/migrate_terraform_statefile.sh
@@ -20,5 +20,5 @@ mv -v ./terraform/.terraform.lock.hcl ./tfstatebackup
 echo "[INFO] copying _backend.tf to terraform folder"
 cp -v ./temp/_backend.tf ./terraform
 
-echo "[INFO] replacing Makefile with commands compatible with Amazon S3 and Amazon DynamoDB backend"
+echo "[INFO] Replacing Makefile with commands compatible with Amazon S3 and Amazon DynamoDB backend"
 cp -vf ./temp/Makefile.s3backend Makefile

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -159,10 +159,37 @@ resource "aws_iam_role_policy" "codebuild_service_role_policy" {
         "iam:CreatePolicy",
         "iam:DeletePolicy",
         "iam:ListPolicyVersions",
-        "iam:ListRolePolicies"
+        "iam:ListRolePolicies",
+        "iam:GetPolicyVersion"
       ],
       "Resource": "*",
       "Effect": "Allow"
+    },
+    {
+      "Sid": "AccessToWriteGrafanaCredsToSSM1",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:DescribeParameters"
+      ],
+      "Resource": [
+        "arn:aws:ssm:*:${local.account_id}:*"
+      ]
+    },
+    {
+      "Sid": "AccessToWriteGrafanaCredsToSSM2",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:DescribeParameters",
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:PutParameter",
+        "ssm:ListTagsForResource",
+        "ssm:AddTagsToResource",
+        "ssm:DeleteParameter"
+      ],
+      "Resource": [
+        "arn:aws:ssm:*:${local.account_id}:parameter/${var.env}/*"
+      ]
     },
     {
       "Sid": "AccessToAmazonDynamoDB",


### PR DESCRIPTION
## Summary
This PR gives the AWS CodeBuild service permissions to add/update AWS SSM Parameter Store parameters.

This is required for storing the admin user credentials for the Grafana dashboard in AWS SSM Parameter Store.